### PR TITLE
User Guide: Enhance PWA documentation with IOS original file handling instructions

### DIFF
--- a/docs/user-guide/library/upload.md
+++ b/docs/user-guide/library/upload.md
@@ -38,3 +38,11 @@
       5. Wähle Dateien aus
 
       6. Klicke *Upload*, um mit dem Hochladen und Importieren der ausgewählten Dateien zu beginnen
+
+!!! info "iOS‑Originale behalten"
+    iOS kann Fotos und Videos in ein besser kompatibles Format umwandeln, **bevor** sie über Safari oder die PhotoPrism‑PWA hochgeladen werden. In diesem Fall erhält und speichert PhotoPrism bereits konvertierte Dateien.
+
+    Damit deine Originale erhalten bleiben:
+
+    - Öffne im iOS‑Fotowähler das Drei‑Punkte‑Menü (…) → *Optionen* und stelle **Format** von **Automatisch** auf **Aktuell**, damit deine Originaldateien erhalten bleiben.
+    - Alternativ kannst du spezielle Sync‑Apps wie [PhotoSync](../sync/sync-phone.md#photosync-verwenden) verwenden, die Dateien im Originalformat per WebDAV hochladen können.

--- a/docs/user-guide/pwa.md
+++ b/docs/user-guide/pwa.md
@@ -28,6 +28,14 @@ Die Kompatibilität unserer PWA wurde mit Apple Safari und Google Chrome geteste
 
         ![Screenshot](img/ios-3.jpg){: style="width:35%" class="shadow"}
 
+    !!! info "iOS‑Originale behalten"
+        iOS kann Fotos und Videos in ein besser kompatibles Format umwandeln, **bevor** sie über Safari oder die PhotoPrism‑PWA hochgeladen werden. In diesem Fall erhält und speichert PhotoPrism bereits konvertierte Dateien.
+
+        Damit deine Originale erhalten bleiben:
+
+        - Öffne im iOS‑Fotowähler das Drei‑Punkte‑Menü (…) → *Optionen* und stelle **Format** von **Automatisch** auf **Aktuell**, damit deine Originaldateien erhalten bleiben.
+        - Alternativ kannst du spezielle Sync‑Apps wie [PhotoSync](sync/sync-phone.md#photosync-verwenden) verwenden, die Dateien im Originalformat per WebDAV hochladen können.
+
 === "Android/Firefox/Chrome"
 
     1. Öffne PhotoPrism im Browser deines Geräts

--- a/docs/user-guide/pwa.md
+++ b/docs/user-guide/pwa.md
@@ -28,6 +28,10 @@ Die Kompatibilität unserer PWA wurde mit Apple Safari und Google Chrome geteste
 
         ![Screenshot](img/ios-3.jpg){: style="width:35%" class="shadow"}
 
+    5. PhotoPrism ist jetzt auf deinem Startbildschirm verfügbar.
+
+        ![Screenshot](img/ios-4.jpg){: style="width:35%" class="shadow"}
+
     !!! info "iOS‑Originale behalten"
         iOS kann Fotos und Videos in ein besser kompatibles Format umwandeln, **bevor** sie über Safari oder die PhotoPrism‑PWA hochgeladen werden. In diesem Fall erhält und speichert PhotoPrism bereits konvertierte Dateien.
 
@@ -47,11 +51,7 @@ Die Kompatibilität unserer PWA wurde mit Apple Safari und Google Chrome geteste
 
         ![Screenshot](img/android-install-app.jpg){: style="width:35%" class="shadow"}
 
-    4.Wähle einen Namen und klicke *Add*
+    4. Wähle einen Namen und klicke *Add*
 
-      ![Screenshot](img/android-3.jpg){: style="width:35%" class="shadow"}
+        ![Screenshot](img/android-3.jpg){: style="width:35%" class="shadow"}
 
-
-PhotoPrism ist jetzt auf deinem Startbildschirm verfügbar.
-
-![Screenshot](img/ios-4.jpg){: style="width:35%" class="shadow"}


### PR DESCRIPTION
This pull request updates the user documentation to clarify how iOS may convert photos and videos before upload, and provides guidance for users who want to keep their original files. The changes add informational callouts and instructions in both the upload guide and the PWA installation guide.