### PR TITLE
User Guide: Sync "KI Modelle nutzen" section with English docs

### DIFF
--- a/docs/user-guide/ai/index.md
+++ b/docs/user-guide/ai/index.md
@@ -27,6 +27,11 @@ PhotoPrism unterstützt derzeit die folgende Dienste:
 
 KI-Engines, Modelle und Laufmodi können in einer `vision.yml` Datei im Verzeichnis `storage/config` konfiguriert werden. Darin wird festgelegt, welche Modelle und Schwellenwerte verwendet werden sollen, zum Beispiel:
 
+!!! info ""
+    Wenn PhotoPrism deine Konfigurationsdatei nicht lesen kann, stelle sicher, dass sie unter dem für deine Instanz konfigurierten Konfigurationspfad existiert. Ältere Installationen verwenden möglicherweise `storage/settings`.
+
+    Führe `docker compose exec photoprism photoprism show config | grep config-path` aus, um deinen konfigurierten Konfigurationspfad zu ermitteln.
+
 ```yaml
 Models:
 - Type: caption
@@ -136,6 +141,7 @@ Unter `Service` konfigurierst du Endpunkt‑URL, HTTP-Methode, Format und Authen
 | `Username` / `Password`            | `""`           | Injected as basic auth when `Uri` lacks userinfo.                                              |
 | `Model`                            | `""`           | Endpoint-specific override; wins over model/name.                                              |
 | `Org` / `Project`                  | `""`           | Organization / Project ID when using OpenAI.                                                   |
+| `Think`                            | `""`           | Optionaler Reasoning-Hint für Ollama. Als String übergebene Werte (`"true"`/`"false"`) werden als JSON-Booleans gesendet. |
 | `RequestFormat` / `ResponseFormat` | engine default | Explicit values win over engine defaults.                                                      |
 | `FileScheme`                       | engine default | Controls image transport e.g. `data` or `base64`.                                              |
 | `Disabled`                         | `false`        | Disables the endpoint without removing the model.                                              |

--- a/docs/user-guide/ai/ollama-cloud.md
+++ b/docs/user-guide/ai/ollama-cloud.md
@@ -24,7 +24,7 @@ Füge die Umgebungsvariablen `OLLAMA_BASE_URL` und `OLLAMA_API_KEY` zum `photopr
 Mit diesen Variablen verwendet PhotoPrism automatisch den Ollama Cloud Endpunkt für alle Ollama‑basierten Modelle, die in deiner [`vision.yml`](index.md#visionyml-reference) konfiguriert sind. Du musst weder `Service.Uri` noch `Service.Key` in der Modellkonfiguration angeben – beides wird aus den Umgebungsvariablen übernommen.
 
 !!! info ""
-    Wenn `OLLAMA_BASE_URL` auf `https://ollama.com` gesetzt ist, wechselt PhotoPrism automatisch zu den Cloud‑Standardeinstellungen. Ein API‑Key allein erzwingt keine Cloud‑Nutzung.
+    Wenn `OLLAMA_BASE_URL` auf `https://ollama.com` gesetzt ist, wechselt PhotoPrism automatisch zu den Cloud‑Standardeinstellungen. Ein API‑Key allein erzwingt keine Cloud‑Nutzung. Da der aktuell veröffentlichte Ollama Cloud Modellname `qwen3-vl:235b-instruct-cloud` lautet, empfehlen wir, ihn explizit in `vision.yml` festzulegen.
 
 ## Schritt 3: Modelle konfigurieren
 
@@ -36,16 +36,24 @@ Da die Service‑URI aus `OLLAMA_BASE_URL` übernommen wird, kannst du den `Serv
     ```yaml
     Models:
     - Type: labels
-      Model: qwen3.5:397b-cloud
+      Model: qwen3-vl:235b-instruct-cloud
       Engine: ollama
       Run: auto
+      Service:
+        Think: "false"
     - Type: caption
-      Model: qwen3.5:397b-cloud
+      Model: qwen3-vl:235b-instruct-cloud
       Engine: ollama
       Run: auto
+      Service:
+        Think: "false"
     ```
 
 Stelle sicher, dass die konfigurierten Modelle [auf Ollama Cloud verfügbar](https://ollama.com/search?c=cloud) sind. Du kannst die [Liste der unterstützten Cloud‑Modelle](https://ollama.com/search?c=cloud) durchsuchen, um zu sehen, welche verwendet werden können. Ein manuelles Herunterladen ist nicht nötig – Cloud‑Modelle werden remote bereitgestellt.
+
+Die optionale Einstellung `Service.Think: "false"` deaktiviert die Reasoning‑Ausgabe bei Modellen, die dies unterstützen. Das ist für Captions und Kategorien oft sinnvoll, da es die Latenz reduziert und verhindert, dass Output‑Tokens für internes Reasoning statt für das eigentliche Ergebnis verbraucht werden.
+
+Zum Zeitpunkt dieser Dokumentation verwendet PhotoPrism intern immer noch `qwen3-vl:235b-instruct` als Ollama Cloud Standardmodell. Durch das explizite Festlegen von `Model: qwen3-vl:235b-instruct-cloud` werden Unklarheiten vermieden, bis dieser Standardwert im Code aktualisiert wird.
 
 [Mehr erfahren ›](ollama-models.md)
 
@@ -82,13 +90,13 @@ Anschließend kannst du die `photoprism vision` [CLI‑Befehle](./cli.md#vision-
 
 ### Konfiguration überprüfen
 
-Wenn es Probleme gibt, solltest du zuerst prüfen, ob die [`vision.yml`](index.md#visionyml-reference) richtig geladen wurde:
+Wenn Probleme auftreten, prüfe zuerst, wie PhotoPrism deine [`vision.yml`](index.md#visionyml-reference)‑Konfiguration geladen hat. Das geht mit folgendem Befehl:
 
 ```bash
 docker compose exec photoprism photoprism vision ls
 ```
 
-Der Befehl gibt die Einstellungen aller unterstützten und konfigurierten Modelltypen aus. Vergleiche das Ergebnis mit deiner [`vision.yml`](index.md#visionyml-reference), um zu prüfen, ob die Konfiguration korrekt übernommen wurde oder Konfigurationsfehler vorliegen.
+Der Befehl gibt die Einstellungen aller unterstützten und konfigurierten Modelltypen aus. Vergleiche das Ergebnis mit deiner [`vision.yml`](index.md#visionyml-reference)‑Datei, um zu bestätigen, dass die Konfiguration korrekt geladen wurde, und um Parsing‑Fehler oder Fehlkonfigurationen zu erkennen.
 
 ### Test Runs durchführen
 
@@ -99,7 +107,7 @@ photoprism vision run -m labels --count 1 --force
 photoprism vision run -m caption --count 1 --force
 ```
 
-Wenn keine Ausgabe erzeugt wird oder Fehler auftreten, wiederhole den Aufruf mit Trace‑Log‑Level:
+Wenn du nicht die erwarteten Ergebnisse erhältst oder Fehler bemerkst, kannst du die Befehle erneut mit aktiviertem Trace‑Log‑Modus ausführen, um Anfrage und Antwort zu untersuchen:
 
 ```bash
 photoprism --log-level=trace vision run -m labels --count 1 --force

--- a/docs/user-guide/ai/ollama-models.md
+++ b/docs/user-guide/ai/ollama-models.md
@@ -1,17 +1,19 @@
 # Ollama Modelle #
 
-Wir empfehlen, ein [Vision Modell](https://ollama.com/search?c=vision) zu wählen, das Geschwindigkeit, Genauigkeit und Zuverlässigkeit gut ausbalanciert. Zwei Modelle, die diese Kriterien erfüllen und die wir besonders empfehlen können, sind [Gemma 3](https://ollama.com/library/gemma3) und [Qwen3‑VL](https://ollama.com/library/qwen3-vl):
+Wir empfehlen, ein [Vision Modell](https://ollama.com/search?c=vision) zu wählen, das Geschwindigkeit, Genauigkeit und Zuverlässigkeit gut ausbalanciert. Zwei Modelle, die diese Kriterien erfüllen und die wir empfehlen können, sind [Gemma 4](https://ollama.com/library/gemma4) und [Qwen3-VL](https://ollama.com/library/qwen3-vl):
 
 | Modell       | Anwendungsfall                                             | Anmerkungen                                                          |
 |--------------|------------------------------------------------------------|----------------------------------------------------------------------|
-| **Gemma 3**  | Standard-Generierung von Bildunterschriften und Labels     | Leichte, zuverlässige JSON-Ausgabe; guter Standard.                  |
-| **Qwen3-VL** | Fortgeschrittene Bilderkennung und Reasoning (OCR, komplexe Prompts) | Bessere visuelle Verankerung (Grounding) und Multi-Language-Support; benötigt mehr VRAM. |
+| **Gemma 4**  | Standard-Generierung von Bildunterschriften und Labels     | Leichte, zuverlässige JSON-Ausgabe; guter Standard.                  |
+| **Qwen3-VL** | Fortgeschrittene Bilderkennung und Reasoning (OCR, komplexe Prompts) | Bessere visuelle Verankerung (Grounding) und Multi-Language-Support; in vielen Größen und Varianten verfügbar. |
 
-[**Gemma 3**](https://ollama.com/library/gemma3) ist in Bezug auf Performance sehr konsistent; Fehler treten nur selten auf. Für sehr lange oder komplexe Prompts und Captions ist es jedoch weniger geeignet. Für die meisten [Anwendungsfälle](#gemma-3-labels) empfehlen wir die Standard‑Variante `gemma3:latest`.
+[**Gemma 4**](https://ollama.com/library/gemma4) ist in Bezug auf Performance sehr konsistent; Fehler treten nur selten auf. Für sehr lange oder komplexe Prompts und Captions ist es jedoch weniger geeignet. Für die meisten [Anwendungsfälle](#gemma-4-labels) empfehlen wir die [Standard‑Variante](https://ollama.com/library/gemma4/tags) `gemma4:latest` (aktuell ein Alias für `gemma4:e4b`). Die kleinere Variante [`gemma4:e2b`](https://ollama.com/library/gemma4/tags) ist spürbar schneller und eine gute Wahl, wenn ein einziges Haupt‑Label pro Bild ausreicht. Wenn du bereits [Gemma 3](https://ollama.com/library/gemma3) konfiguriert hast, funktioniert das weiterhin – Gemma 4 ist ein Drop‑in‑Ersatz mit vergleichbarer Latenz (ca. 2 Sekunden für die Label‑Generierung auf einer NVIDIA RTX 4060 in unseren Tests).
 
-[**Qwen3‑VL**](https://ollama.com/library/qwen3-vl) verhält sich in den kleineren `2b`‑ und `4b`‑[Varianten](https://ollama.com/library/qwen3-vl/tags) weniger vorhersehbar; Leistung und Fehlerrate können stark schwanken – [es sei denn, du steuerst es wie in den Beispielen](#qwen3-vl-labels) weiter unten. Die Standardversion `qwen3-vl:latest` (`8b`) funktioniert im Allgemeinen ohne größere Anpassungen gut. Auf einer NVIDIA RTX 4060 ist Qwen3‑VL bei der [Label‑Generierung mit 2–3 Sekunden](#qwen3-vl-labels) pro Bild etwas langsamer als Gemma 3 mit [1–2 Sekunden](#gemma-3-labels).
+[**Qwen3‑VL**](https://ollama.com/library/qwen3-vl) verhält sich in den kleineren `2b`‑ und `4b`‑[Varianten](https://ollama.com/library/qwen3-vl/tags) weniger vorhersehbar; Leistung und Fehlerrate können stark schwanken – [es sei denn, du steuerst es wie in den Beispielen](#qwen3-vl-labels) weiter unten. Die Standardversion `qwen3-vl:latest` (`8b`) funktioniert im Allgemeinen ohne größere Anpassungen gut. Die Label‑Generierung auf einer NVIDIA RTX 4060 dauert typischerweise [2–3 Sekunden](#qwen3-vl-labels) und ist damit in etwa vergleichbar mit [Gemma 4](#gemma-4-labels).
 
-Die Performance hängt außerdem von deiner Hardware ab. Auf Apple Silicon oder NVIDIA‑Blackwell‑GPUs können z.B. bestimmte [Qwen3‑VL‑Varianten](https://ollama.com/search?q=qwen3-vl) schneller sein als Gemma 3. Am besten testest du beide Modelle und entscheidest, welches für deinen Anwendungsfall besser funktioniert. Wenn du sowohl Captions als auch Labels erzeugst, solltest du möglichst dasselbe Modell verwenden, damit Ollama nicht zwischen Modellen hin‑ und herschalten muss.
+Eine neuere Community‑Variante, [`frob/qwen3.5-instruct:4b`](https://ollama.com/frob/qwen3.5-instruct), hat sich in unseren Tests als fähige Alternative erwiesen – sie nutzt dasselbe Options‑Profil wie `qwen3-vl:4b-instruct` (siehe [unten](#qwen3-vl-labels)) und liefert eine vergleichbare Latenz. In einer begrenzten Testreihe haben wir leicht bessere Ergebnisse bei weniger verbreiteten Motiven beobachtet (zum Beispiel wird ein Chamäleon korrekt als „chameleon“ erkannt und nicht als generisches „lizard“, wie es einige andere 4B‑Modelle zurückgeben). Wie bei allen Qwen‑Modellen müssen die strikten Options und das Prompt‑Schema „AT MOST N labels“ beibehalten werden – ohne sie erzeugt das Modell zu viele Tokens und die JSON‑Antwort wird abgeschnitten.
+
+Die Performance hängt außerdem von deiner Hardware ab. Auf Apple Silicon oder NVIDIA‑Blackwell‑GPUs können z.B. bestimmte [Qwen3‑VL‑Varianten](https://ollama.com/search?q=qwen3-vl) schneller sein als Gemma 4. Am besten testest du beide Modelle und entscheidest, welches für deinen Anwendungsfall besser funktioniert. Wenn du sowohl Captions als auch Labels erzeugst, solltest du möglichst dasselbe Modell verwenden, damit Ollama nicht zwischen Modellen hin‑ und herschalten muss.
 
 !!! tldr ""
     Ohne GPU‑Beschleunigung sind Ollama‑Modelle deutlich langsamer und benötigen zwischen 10 Sekunden und über einer Minute pro Bild. Das kann in Ordnung sein, wenn du nur wenige Bilder verarbeiten möchtest oder Wartezeiten akzeptabel sind.
@@ -58,12 +60,12 @@ Für andere Sprachen sollten die Basisanweisungen im Prompt auf Englisch bleiben
 
 Die folgenden Beispiele kannst du direkt in deiner `vision.yml` verwenden. Die Datei liegt im Verzeichnis `storage/config`. [Mehr erfahren ›](index.md#visionyml-reference).
 
-### Gemma 3: Labels
+### Gemma 4: Labels
 
 ```yaml
 Models:
 - Type: labels
-  Model: gemma3:latest
+  Model: gemma4:latest
   Engine: ollama
   Run: auto
   Service:
@@ -74,13 +76,14 @@ Warum das funktioniert:
 
 - **Engine:** Verwendet sinnvolle Standardwerte für **Resolution**, **Format**, **Prompt** und **Options** (720 px‑Thumbnails, JSON‑Prompts für Labels). Ein eigener Prompt ist nicht notwendig.
 - **Run:** `auto` läuft automatisch nach der Indexierung und durch geplante Jobs. Kann zusätzlich manuell ausgeführt werden ￫ [Run Modes](index.md#run-modes).
+- **Model:** `gemma4:latest` ist aktuell ein Alias für `gemma4:e4b` und liefert drei bis vier Labels pro Bild mit abgestufter Topicality. Für einen schnelleren Klassifizierer mit einem einzelnen Haupt‑Label pro Bild wechsle zu `gemma4:e2b`.
 
-### Gemma 3: Caption
+### Gemma 4: Caption
 
 ```yaml
 Models:
 - Type: caption
-  Model: gemma3:latest
+  Model: gemma4:latest
   Engine: ollama
   Run: auto
   Prompt: >
@@ -128,7 +131,7 @@ Models:
 
 Warum das funktioniert:
 
-- **Model:** [`qwen3-vl:4b-instruct`](https://ollama.com/library/qwen3-vl/tags) ist eine leichtere Qwen3‑VL‑Variante. Alternativ kannst du [`huihui_ai/qwen3-vl-abliterated:4b-instruct`](https://ollama.com/huihui_ai/qwen3-vl-abliterated), [`qwen3-vl:latest`](https://ollama.com/library/qwen3-vl) oder andere [Varianten](https://ollama.com/search?c=vision&q=qwen3-vl) ausprobieren.
+- **Model:** [`qwen3-vl:4b-instruct`](https://ollama.com/library/qwen3-vl/tags) ist eine leichtere Qwen3‑VL‑Variante. Alternativ kannst du [`frob/qwen3.5-instruct:4b`](https://ollama.com/frob/qwen3.5-instruct) (eine neuere Community‑Variante; nutzt dasselbe Options‑Profil und hat in unseren Tests leicht bessere Ergebnisse bei weniger verbreiteten Motiven geliefert), [`huihui_ai/qwen3-vl-abliterated:4b-instruct`](https://ollama.com/huihui_ai/qwen3-vl-abliterated), [`qwen3-vl:latest`](https://ollama.com/library/qwen3-vl) oder andere [Varianten](https://ollama.com/search?c=vision&q=qwen3-vl) ausprobieren.
 - **Engine:** Wendet sinnvolle Standardwerte für **Resolution**, **Format** und **Options** an.
 - **Run:** `on-demand` erlaubt manuelle Läufe, Ausführungen durch den Metadata‑Worker und geplante Jobs ￫ [Run Modes](index.md#run-modes).
 - **Prompt:** Begrenzte Latenz, keine Wiederholungen und klare Kontrolle über Art und Anzahl der zurückgegebenen Labels. Für andere Sprachen ergänze „Respond in …“ im Prompt.
@@ -171,7 +174,7 @@ Models:
 
 Warum das funktioniert:
 
-- **Model:** Die Verwendung von [`qwen3-vl:4b-instruct`](https://ollama.com/library/qwen3-vl/tags) für Labels und Captions vermeidet zeitaufwändige Modellwechsel in Ollama. Alternativ kannst du [`huihui_ai/qwen3-vl-abliterated:4b-instruct`](https://ollama.com/huihui_ai/qwen3-vl-abliterated), [`qwen3-vl:latest`](https://ollama.com/library/qwen3-vl) oder andere [Varianten](https://ollama.com/search?c=vision&q=qwen3-vl) testen.
+- **Model:** Die Verwendung von [`qwen3-vl:4b-instruct`](https://ollama.com/library/qwen3-vl/tags) für Labels und Captions vermeidet zeitaufwändige Modellwechsel in Ollama. Alternativ kannst du [`frob/qwen3.5-instruct:4b`](https://ollama.com/frob/qwen3.5-instruct) (eine neuere Community‑Variante; nutzt dasselbe Options‑Profil und hat in unseren Tests leicht bessere Ergebnisse bei weniger verbreiteten Motiven geliefert), [`huihui_ai/qwen3-vl-abliterated:4b-instruct`](https://ollama.com/huihui_ai/qwen3-vl-abliterated), [`qwen3-vl:latest`](https://ollama.com/library/qwen3-vl) oder andere [Varianten](https://ollama.com/search?c=vision&q=qwen3-vl) testen.
 - **Engine:** Wendet sinnvolle Standardwerte für **Resolution**, **Format** und **Options** an.
 - **Run:** `on-schedule` erlaubt manuelle Läufe und geplante Jobs ￫ [Run Modes](index.md#run-modes).
 - **System:** Weist das Modell an, Bilder in natürlicher Sprache zu beschreiben.
@@ -205,3 +208,31 @@ photoprism vision run -m labels
 ```
 
 [Learn more ›](cli.md)
+
+## Troubleshooting
+
+### Konfiguration überprüfen
+
+Wenn Probleme auftreten, prüfe zuerst, wie PhotoPrism deine [`vision.yml`](index.md#visionyml-reference)‑Konfiguration geladen hat. Das geht mit folgendem Befehl:
+
+```bash
+docker compose exec photoprism photoprism vision ls
+```
+
+Der Befehl gibt die Einstellungen aller unterstützten und konfigurierten Modelltypen aus. Vergleiche das Ergebnis mit deiner [`vision.yml`](index.md#visionyml-reference)‑Datei, um zu bestätigen, dass die Konfiguration korrekt geladen wurde, und um Parsing‑Fehler oder Fehlkonfigurationen zu erkennen.
+
+### Test Runs durchführen
+
+Die folgenden [Terminal‑Befehle](https://docs.photoprism.app/getting-started/docker-compose/#opening-a-terminal) führen jeweils einen einzelnen Lauf für den angegebenen Modelltyp aus:
+
+```bash
+photoprism vision run -m labels --count 1 --force
+photoprism vision run -m caption --count 1 --force
+```
+
+Wenn du nicht die erwarteten Ergebnisse erhältst oder Fehler bemerkst, kannst du die Befehle erneut mit aktiviertem Trace‑Log‑Modus ausführen, um Anfrage und Antwort zu untersuchen:
+
+```bash
+photoprism --log-level=trace vision run -m labels --count 1 --force
+photoprism --log-level=trace vision run -m caption --count 1 --force
+```

--- a/docs/user-guide/ai/using-ollama.md
+++ b/docs/user-guide/ai/using-ollama.md
@@ -87,6 +87,11 @@ docker compose exec ollama ollama pull gemma3:latest
 
 Erstelle nun eine neue Datei `config/vision.yml` oder bearbeite die vorhandene Datei im *storage*‑Verzeichnis deiner PhotoPrism‑Instanz, wie im folgenden Beispiel. Aus Sicht des Containers befindet sich die Datei unter `/photoprism/storage/config/vision.yml`:
 
+!!! info ""
+    Wenn PhotoPrism deine Konfigurationsdatei nicht lesen kann, stelle sicher, dass sie unter dem für deine Instanz konfigurierten Konfigurationspfad existiert. Ältere Installationen verwenden möglicherweise `storage/settings`.
+
+    Führe `docker compose exec photoprism photoprism show config | grep config-path` aus, um deinen konfigurierten Konfigurationspfad zu ermitteln.
+
 !!! example "vision.yml"
     ```yaml
     Models:
@@ -139,13 +144,13 @@ Anschließend kannst du die `photoprism vision` [CLI‑Befehle](./cli.md#vision-
 
 ### Konfiguration überprüfen
 
-Wenn es Probleme gibt, solltest du zuerst prüfen, ob die `vision.yml` richtig geladen wurde.
+Wenn Probleme auftreten, prüfe zuerst, wie PhotoPrism deine [`vision.yml`](index.md#visionyml-reference)‑Konfiguration geladen hat. Das geht mit folgendem Befehl:
 
 ```bash
 docker compose exec photoprism photoprism vision ls
 ```
 
-Der Befehl gibt die Einstellungen aller unterstützten und konfigurierten Modelltypen aus. Vergleiche das Ergebnis mit deiner `vision.yml`, um zu prüfen, ob die Konfiguration korrekt übernommen wurde oder Konfigurationsfehler vorliegen.
+Der Befehl gibt die Einstellungen aller unterstützten und konfigurierten Modelltypen aus. Vergleiche das Ergebnis mit deiner [`vision.yml`](index.md#visionyml-reference)‑Datei, um zu bestätigen, dass die Konfiguration korrekt geladen wurde, und um Parsing‑Fehler oder Fehlkonfigurationen zu erkennen.
 
 ### Test Runs durchführen
 
@@ -156,7 +161,7 @@ photoprism vision run -m labels --count 1 --force
 photoprism vision run -m caption --count 1 --force
 ```
 
-Wenn keine Ausgabe erzeugt wird, wiederhole den Aufruf mit einem höhreren Log Level.
+Wenn du nicht die erwarteten Ergebnisse erhältst oder Fehler bemerkst, kannst du die Befehle erneut mit aktiviertem Trace‑Log‑Modus ausführen, um Anfrage und Antwort zu untersuchen:
 
 ```bash
 photoprism --log-level=trace vision run -m labels --count 1 --force
@@ -167,7 +172,18 @@ photoprism --log-level=trace vision run -m caption --count 1 --force
 
 Wenn du ein Reasoning‑ oder „Thinking"‑Modell verwendest und unvollständige oder abgeschnittene Captions erhältst, verbraucht das Modell möglicherweise den Großteil seines Output‑Token‑Budgets für internes Reasoning – sodass zu wenige Tokens für die eigentliche Caption übrig bleiben.
 
-Um das zu beheben, wechsle entweder zu einem Modell ohne Thinking oder erhöhe den Wert von `NumPredict` in den [`vision.yml`](index.md#visionyml-reference) [Optionen](index.md#options), um dem Modell mehr Spielraum zu geben:
+Um das zu beheben, kannst du entweder Reasoning für das Modell mit `Service.Think: "false"` deaktivieren, zu einem Modell ohne Thinking wechseln oder den Wert von `NumPredict` in den [`vision.yml`](index.md#visionyml-reference) [Optionen](index.md#options) erhöhen, um dem Modell mehr Spielraum zu geben:
+
+```yaml
+Models:
+- Type: caption
+  Model: qwen3-vl:235b-instruct
+  Engine: ollama
+  Service:
+    Think: "false"
+```
+
+Wenn Reasoning weiterhin aktiviert bleiben soll, erhöhe das Output‑Budget für die eigentliche Caption:
 
 ```yaml
 Options:

--- a/docs/user-guide/ai/using-openai.md
+++ b/docs/user-guide/ai/using-openai.md
@@ -41,7 +41,7 @@ Empfehlungen:
 - PhotoPrism wertet Modelle von unten nach oben aus. Wenn du die OpenAI‑Einträge ans Ende der Liste setzt, werden sie bevorzugt, während andere Modelle als Fallback dienen.
 
 !!! tldr ""
-    Standardmäßig verwendet PhotoPrism den OpenAI‑Responses‑Endpunkt `https://api.openai.com/v1/responses` mit einem einzelnen 720 px Thumbnail (`detail: low`).
+    Standardmäßig verwendet PhotoPrism den OpenAI‑Responses‑Endpunkt `https://api.openai.com/v1/responses` mit einem einzelnen 720 px Thumbnail (`detail: low`). Der Endpunkt lässt sich über `Service.Url` auf einen eigenen Wert ändern.
 
 ## Nutzungs Tipps
 
@@ -112,13 +112,13 @@ Models:
 
 ### Konfiguration überprüfen
 
-Wenn es Probleme gibt, solltest du zuerst prüfen, ob die `vision.yml` richtig geladen wurde.
+Wenn Probleme auftreten, prüfe zuerst, wie PhotoPrism deine [`vision.yml`](index.md#visionyml-reference)‑Konfiguration geladen hat. Das geht mit folgendem Befehl:
 
 ```bash
 docker compose exec photoprism photoprism vision ls
 ```
 
-Der Befehl gibt die Einstellungen aller unterstützten und konfigurierten Modelltypen aus. Vergleiche das Ergebnis mit deiner `vision.yml`, um zu prüfen, ob die Konfiguration korrekt übernommen wurde oder Konfigurationsfehler vorliegen.
+Der Befehl gibt die Einstellungen aller unterstützten und konfigurierten Modelltypen aus. Vergleiche das Ergebnis mit deiner [`vision.yml`](index.md#visionyml-reference)‑Datei, um zu bestätigen, dass die Konfiguration korrekt geladen wurde, und um Parsing‑Fehler oder Fehlkonfigurationen zu erkennen.
 
 ### Test Runs durchführen
 
@@ -129,7 +129,7 @@ photoprism vision run -m labels --count 1 --force
 photoprism vision run -m caption --count 1 --force
 ```
 
-Wenn keine Ausgabe erzeugt wird, wiederhole den Aufruf mit einem höhreren Log Level.
+Wenn du nicht die erwarteten Ergebnisse erhältst oder Fehler bemerkst, kannst du die Befehle erneut mit aktiviertem Trace‑Log‑Modus ausführen, um Anfrage und Antwort zu untersuchen:
 
 ```bash
 photoprism --log-level=trace vision run -m labels --count 1 --force


### PR DESCRIPTION
## Summary

Syncs the **KI Modelle nutzen** section with the current English user guide.

- `ai/index.md` — adds the config-path hint admonition; adds the `Service.Think` row to the Service table.
- `ai/using-ollama.md` — adds the config-path admonition; sharper troubleshooting wording; documents `Service.Think: "false"` as a third remediation for incomplete captions from thinking models.
- `ai/ollama-cloud.md` — **fixes the stale model name** in the example (`qwen3.5:397b-cloud` → `qwen3-vl:235b-instruct-cloud`); adds `Service.Think: "false"` to the yaml; extends the info-box to recommend pinning the cloud model explicitly; adds the two short explanations that follow the example.
- `ai/ollama-models.md` — renames Gemma 3 to Gemma 4 throughout (headings, body, yaml); adds `gemma4:e2b` and `frob/qwen3.5-instruct:4b` guidance; adds the full Troubleshooting section.
- `ai/using-openai.md` — notes that `Service.Url` overrides the endpoint; tightens troubleshooting wording; fixes the `höhreren` typo.
- `ai/cli.md` — already in sync.

No screenshots changed — this section uses none.

## Test plan

- [ ] `make watch` and skim each changed page in the browser.
- [ ] `grep qwen3.5:397b-cloud docs/` returns nothing.